### PR TITLE
Database storage

### DIFF
--- a/conversiontracking.php
+++ b/conversiontracking.php
@@ -27,6 +27,8 @@
 if (!defined('_PS_VERSION_'))
 	exit;
 
+require_once(dirname(__FILE__).'/dataAccess.php');
+
 class conversiontracking extends Module
 {
 	protected $config_form = false;
@@ -211,8 +213,16 @@ class conversiontracking extends Module
 	 */
 	public function hookDisplayOrderConfirmation($params)
 	{
-		$fbTrackers = array();
-		$adwordsTrackers = array();
+		$groupId = (int)$this->context->shop->getContextShopGroupID();
+		$shopId = (int)$this->context->shop->getContextShopID();
+		$scriptTemplateData = fetchScriptTemplateData($groupId, $shopId);
+
+		$fbTrackers = array_key_exists('fbPixel', $scriptTemplateData) ?
+			$scriptTemplateData['fbPixel'] :
+			array();
+		$adwordsTrackers = array_key_exists('adwords', $scriptTemplateData) ?
+			$scriptTemplateData['adwords'] :
+			array();;
 
 		$this->smarty->assign(array(
 			'fbTrackers' => $fbTrackers,

--- a/dataAccess.php
+++ b/dataAccess.php
@@ -1,0 +1,53 @@
+<?php
+
+function fetchScriptData($groupId, $shopId) {
+	$scriptData = array();
+
+	$sql = 'SELECT
+		`'._DB_PREFIX_.'conversiontracking`.`id_conversiontracking`,
+		`'._DB_PREFIX_.'conversiontracking_service`.`template_service_id`,
+		`'._DB_PREFIX_.'conversiontracking_field`.`template_field_id`,
+		`'._DB_PREFIX_.'conversiontracking_value`.`field_value`
+	FROM `'._DB_PREFIX_.'conversiontracking`
+	INNER JOIN `'._DB_PREFIX_.'conversiontracking_service`
+		ON `'._DB_PREFIX_.'conversiontracking`.`id_conversiontracking_service` = `'._DB_PREFIX_.'conversiontracking_service`.`id_conversiontracking_service`
+	INNER JOIN `'._DB_PREFIX_.'conversiontracking_value`
+		ON `'._DB_PREFIX_.'conversiontracking`.`id_conversiontracking` = `'._DB_PREFIX_.'conversiontracking_value`.`id_conversiontracking`
+	INNER JOIN `'._DB_PREFIX_.'conversiontracking_field`
+		ON `'._DB_PREFIX_.'conversiontracking_value`.`id_conversiontracking_field` = `'._DB_PREFIX_.'conversiontracking_field`.`id_conversiontracking_field`
+	WHERE `'._DB_PREFIX_.'conversiontracking`.`id_group` in (0, '. (int)$groupId .')
+		AND `'._DB_PREFIX_.'conversiontracking`.`id_shop` in (0, '. (int)$shopId .')
+	ORDER BY 
+		`'._DB_PREFIX_.'conversiontracking`.`id_shop` DESC,
+		`'._DB_PREFIX_.'conversiontracking`.`id_group` DESC,
+		`'._DB_PREFIX_.'conversiontracking_field`.`id_conversiontracking_field` ASC;';
+
+	return Db::getInstance()->ExecuteS($sql);
+}
+
+function fetchScriptTemplateData($groupId, $shopId) {
+	$scriptTemplateData = array();
+	$scriptData = fetchScriptData($groupId, $shopId);
+
+	if($scriptData) {
+		// flatten into key-value pairs grouped by service
+		foreach($scriptData as $row) {
+			$serviceId = $row['template_service_id'];
+			$recordId = $row['id_conversiontracking'];
+			$templateKey = $row['template_field_id'];
+			$templateValue = $row['field_value'];
+
+			if(!array_key_exists($serviceId, $scriptTemplateData)) {
+				$scriptTemplateData[$serviceId] = array();
+			}
+			if(!array_key_exists($recordId, $scriptTemplateData[$serviceId])) {
+				$scriptTemplateData[$serviceId][$recordId] = array();
+			}
+
+			// add key, value
+			$scriptTemplateData[$serviceId][$recordId][$templateKey] = $templateValue;
+		}
+	}
+
+	return $scriptTemplateData;
+}

--- a/sql/install.php
+++ b/sql/install.php
@@ -63,6 +63,59 @@ $sql[] = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'conversiontracking_value` (
 ) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8;';
 
 
+/* Define service: Google AdWords */
+$sql[] = "INSERT INTO `"._DB_PREFIX_."conversiontracking_service`
+	(`service_name`, `service_description`)
+VALUES
+	('adwords', 'Google AdWords');";
+
+$sql[] = "INSERT INTO `"._DB_PREFIX_."conversiontracking_field`
+	(`id_conversiontracking_service`, `field_name`, `field_description`, `validation_expression`, `validation_message`)
+SELECT
+	`"._DB_PREFIX_."conversiontracking_service`.`id_conversiontracking_service`,
+	`fields`.`field_name`,
+	`fields`.`field_description`,
+	`fields`.`validation_expression`,
+	`fields`.`validation_message`
+FROM `"._DB_PREFIX_."conversiontracking_service`
+INNER JOIN (
+	SELECT
+		'ID' as `field_name`,
+		'google_conversion_id' as `field_description`,
+		'^[0-9]+$' as `validation_expression`,
+		'ID can only contain numbers' as `validation_message`
+	UNION ALL
+	SELECT
+		'Label' as `field_name`,
+		'google_conversion_label' as `field_description`,
+		'^[A-Za-z0-9]+$' as `validation_expression`,
+		'Label can only contain letters and numbers' as `validation_message`
+) `fields`
+LEFT JOIN `"._DB_PREFIX_."conversiontracking_field`
+	ON `"._DB_PREFIX_."conversiontracking_service`.`id_conversiontracking_service` = `"._DB_PREFIX_."conversiontracking_field`.`id_conversiontracking_service`
+WHERE `"._DB_PREFIX_."conversiontracking_service`.`service_name` = 'adwords'
+	AND `"._DB_PREFIX_."conversiontracking_field`.`id_conversiontracking_field` IS NULL;";
+
+/* Define service: Facebook Conversion Pixel */
+$sql[] = "INSERT INTO `"._DB_PREFIX_."conversiontracking_service`
+	(`service_name`, `service_description`)
+VALUES
+	('fbPixel', 'Facebook Conversion Tracking Pixel');";
+
+$sql[] = "INSERT INTO `"._DB_PREFIX_."conversiontracking_field`
+	(`id_conversiontracking_service`, `field_name`, `field_description`, `validation_expression`, `validation_message`)
+SELECT
+	`"._DB_PREFIX_."conversiontracking_service`.`id_conversiontracking_service`,
+	'ID' as `field_name`,
+	'Checkout Pixel ID' as `field_description`,
+	'^[0-9]+$' as `validation_expression`,
+	'ID can only contain numbers' as `validation_message`
+FROM `"._DB_PREFIX_."conversiontracking_service`
+LEFT JOIN `"._DB_PREFIX_."conversiontracking_field`
+	ON `"._DB_PREFIX_."conversiontracking_service`.`id_conversiontracking_service` = `"._DB_PREFIX_."conversiontracking_field`.`id_conversiontracking_service`
+WHERE `"._DB_PREFIX_."conversiontracking_service`.`service_name` = 'fbPixel'
+	AND `"._DB_PREFIX_."conversiontracking_field`.`id_conversiontracking_field` IS NULL;";
+
 
 /* Execute */
 foreach ($sql as $query)

--- a/sql/install.php
+++ b/sql/install.php
@@ -26,11 +26,45 @@
 
 $sql = array();
 
-$sql[] = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'conversiontracking` (
-    `id_conversiontracking` int(11) NOT NULL AUTO_INCREMENT,
-    PRIMARY KEY  (`id_conversiontracking`)
+/* Create tables */
+$sql[] = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'conversiontracking_service` (
+    `id_conversiontracking_service` int(11) NOT NULL AUTO_INCREMENT,
+    `service_name` varchar(24) NOT NULL,
+    `service_description` varchar(128),
+    PRIMARY KEY  (`id_conversiontracking_service`)
 ) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8;';
 
+$sql[] = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'conversiontracking_field` (
+	`id_conversiontracking_field` int(11) NOT NULL AUTO_INCREMENT,
+	`id_conversiontracking_service` int(11) NOT NULL,
+	`field_name` varchar(32) NOT NULL,
+	`field_description` varchar(128),
+	`validation_expression` varchar(64),
+	`validation_message` varchar(64),
+	PRIMARY KEY (`id_conversiontracking_field`)
+) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8;';
+
+$sql[] = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'conversiontracking` (
+	`id_conversiontracking` int(11) NOT NULL AUTO_INCREMENT,
+	`id_conversiontracking_service` int(11) NOT NULL,
+	`id_group` int(11) NOT NULL DEFAULT 0,
+	`id_shop` int(11) NOT NULL DEFAULT 0,
+	PRIMARY KEY (`id_conversiontracking`),
+	INDEX idx_group_shop (`id_group`, `id_shop`)
+) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8;';
+
+$sql[] = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'conversiontracking_value` (
+	`id_conversiontracking_value` int(11) NOT NULL AUTO_INCREMENT,
+	`id_conversiontracking` int(11) NOT NULL,
+	`id_conversiontracking_field` int(11) NOT NULL,
+	`field_value` varchar(32),
+	PRIMARY KEY (`id_conversiontracking_value`),
+	INDEX idx_conversiontracking (`id_conversiontracking`)
+) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8;';
+
+
+
+/* Execute */
 foreach ($sql as $query)
 	if (Db::getInstance()->execute($query) == false)
 		return false;

--- a/sql/install.php
+++ b/sql/install.php
@@ -29,8 +29,8 @@ $sql = array();
 /* Create tables */
 $sql[] = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'conversiontracking_service` (
     `id_conversiontracking_service` int(11) NOT NULL AUTO_INCREMENT,
-    `service_name` varchar(24) NOT NULL,
-    `service_description` varchar(128),
+    `service_id` varchar(24) NOT NULL,
+    `service_name` varchar(128) NOT NULL,
     PRIMARY KEY  (`id_conversiontracking_service`)
 ) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8;';
 
@@ -65,7 +65,7 @@ $sql[] = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'conversiontracking_value` (
 
 /* Define service: Google AdWords */
 $sql[] = "INSERT INTO `"._DB_PREFIX_."conversiontracking_service`
-	(`service_name`, `service_description`)
+	(`service_id`, `service_name`)
 VALUES
 	('adwords', 'Google AdWords');";
 
@@ -93,12 +93,12 @@ INNER JOIN (
 ) `fields`
 LEFT JOIN `"._DB_PREFIX_."conversiontracking_field`
 	ON `"._DB_PREFIX_."conversiontracking_service`.`id_conversiontracking_service` = `"._DB_PREFIX_."conversiontracking_field`.`id_conversiontracking_service`
-WHERE `"._DB_PREFIX_."conversiontracking_service`.`service_name` = 'adwords'
+WHERE `"._DB_PREFIX_."conversiontracking_service`.`service_id` = 'adwords'
 	AND `"._DB_PREFIX_."conversiontracking_field`.`id_conversiontracking_field` IS NULL;";
 
 /* Define service: Facebook Conversion Pixel */
 $sql[] = "INSERT INTO `"._DB_PREFIX_."conversiontracking_service`
-	(`service_name`, `service_description`)
+	(`service_id`, `service_name`)
 VALUES
 	('fbPixel', 'Facebook Conversion Tracking Pixel');";
 
@@ -113,7 +113,7 @@ SELECT
 FROM `"._DB_PREFIX_."conversiontracking_service`
 LEFT JOIN `"._DB_PREFIX_."conversiontracking_field`
 	ON `"._DB_PREFIX_."conversiontracking_service`.`id_conversiontracking_service` = `"._DB_PREFIX_."conversiontracking_field`.`id_conversiontracking_service`
-WHERE `"._DB_PREFIX_."conversiontracking_service`.`service_name` = 'fbPixel'
+WHERE `"._DB_PREFIX_."conversiontracking_service`.`service_id` = 'fbPixel'
 	AND `"._DB_PREFIX_."conversiontracking_field`.`id_conversiontracking_field` IS NULL;";
 
 

--- a/sql/install.php
+++ b/sql/install.php
@@ -29,7 +29,7 @@ $sql = array();
 /* Create tables */
 $sql[] = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'conversiontracking_service` (
     `id_conversiontracking_service` int(11) NOT NULL AUTO_INCREMENT,
-    `service_id` varchar(24) NOT NULL,
+    `template_service_id` varchar(24) NOT NULL,
     `service_name` varchar(64) NOT NULL,
     PRIMARY KEY  (`id_conversiontracking_service`)
 ) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8;';
@@ -37,7 +37,7 @@ $sql[] = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'conversiontracking_service`
 $sql[] = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'conversiontracking_field` (
 	`id_conversiontracking_field` int(11) NOT NULL AUTO_INCREMENT,
 	`id_conversiontracking_service` int(11) NOT NULL,
-	`field_id` varchar(24) NOT NULL,
+	`template_field_id` varchar(24) NOT NULL,
 	`field_name` varchar(32) NOT NULL,
 	`field_description` varchar(128),
 	`validation_expression` varchar(64),
@@ -66,15 +66,15 @@ $sql[] = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'conversiontracking_value` (
 
 /* Define service: Google AdWords */
 $sql[] = "INSERT INTO `"._DB_PREFIX_."conversiontracking_service`
-	(`service_id`, `service_name`)
+	(`template_service_id`, `service_name`)
 VALUES
 	('adwords', 'Google AdWords');";
 
 $sql[] = "INSERT INTO `"._DB_PREFIX_."conversiontracking_field`
-	(`id_conversiontracking_service`, `field_id`, `field_name`, `field_description`, `validation_expression`, `validation_message`)
+	(`id_conversiontracking_service`, `template_field_id`, `field_name`, `field_description`, `validation_expression`, `validation_message`)
 SELECT
 	`"._DB_PREFIX_."conversiontracking_service`.`id_conversiontracking_service`,
-	`fields`.`field_id`,
+	`fields`.`template_field_id`,
 	`fields`.`field_name`,
 	`fields`.`field_description`,
 	`fields`.`validation_expression`,
@@ -82,14 +82,14 @@ SELECT
 FROM `"._DB_PREFIX_."conversiontracking_service`
 INNER JOIN (
 	SELECT
-		'id' as `field_id`,
+		'id' as `template_field_id`,
 		'ID' as `field_name`,
 		'google_conversion_id' as `field_description`,
 		'^[0-9]+$' as `validation_expression`,
 		'ID can only contain numbers' as `validation_message`
 	UNION ALL
 	SELECT
-		'label' as `field_id`,
+		'label' as `template_field_id`,
 		'Label' as `field_name`,
 		'google_conversion_label' as `field_description`,
 		'^[A-Za-z0-9]+$' as `validation_expression`,
@@ -97,20 +97,20 @@ INNER JOIN (
 ) `fields`
 LEFT JOIN `"._DB_PREFIX_."conversiontracking_field`
 	ON `"._DB_PREFIX_."conversiontracking_service`.`id_conversiontracking_service` = `"._DB_PREFIX_."conversiontracking_field`.`id_conversiontracking_service`
-WHERE `"._DB_PREFIX_."conversiontracking_service`.`service_id` = 'adwords'
+WHERE `"._DB_PREFIX_."conversiontracking_service`.`template_service_id` = 'adwords'
 	AND `"._DB_PREFIX_."conversiontracking_field`.`id_conversiontracking_field` IS NULL;";
 
 /* Define service: Facebook Conversion Pixel */
 $sql[] = "INSERT INTO `"._DB_PREFIX_."conversiontracking_service`
-	(`service_id`, `service_name`)
+	(`template_service_id`, `service_name`)
 VALUES
 	('fbPixel', 'Facebook Conversion Tracking Pixel');";
 
 $sql[] = "INSERT INTO `"._DB_PREFIX_."conversiontracking_field`
-	(`id_conversiontracking_service`, `field_id`, `field_name`, `field_description`, `validation_expression`, `validation_message`)
+	(`id_conversiontracking_service`, `template_field_id`, `field_name`, `field_description`, `validation_expression`, `validation_message`)
 SELECT
 	`"._DB_PREFIX_."conversiontracking_service`.`id_conversiontracking_service`,
-	'id' as `field_id`,
+	'id' as `template_field_id`,
 	'ID' as `field_name`,
 	'Checkout Pixel ID' as `field_description`,
 	'^[0-9]+$' as `validation_expression`,
@@ -118,7 +118,7 @@ SELECT
 FROM `"._DB_PREFIX_."conversiontracking_service`
 LEFT JOIN `"._DB_PREFIX_."conversiontracking_field`
 	ON `"._DB_PREFIX_."conversiontracking_service`.`id_conversiontracking_service` = `"._DB_PREFIX_."conversiontracking_field`.`id_conversiontracking_service`
-WHERE `"._DB_PREFIX_."conversiontracking_service`.`service_id` = 'fbPixel'
+WHERE `"._DB_PREFIX_."conversiontracking_service`.`template_service_id` = 'fbPixel'
 	AND `"._DB_PREFIX_."conversiontracking_field`.`id_conversiontracking_field` IS NULL;";
 
 

--- a/sql/install.php
+++ b/sql/install.php
@@ -30,13 +30,14 @@ $sql = array();
 $sql[] = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'conversiontracking_service` (
     `id_conversiontracking_service` int(11) NOT NULL AUTO_INCREMENT,
     `service_id` varchar(24) NOT NULL,
-    `service_name` varchar(128) NOT NULL,
+    `service_name` varchar(64) NOT NULL,
     PRIMARY KEY  (`id_conversiontracking_service`)
 ) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8;';
 
 $sql[] = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'conversiontracking_field` (
 	`id_conversiontracking_field` int(11) NOT NULL AUTO_INCREMENT,
 	`id_conversiontracking_service` int(11) NOT NULL,
+	`field_id` varchar(24) NOT NULL,
 	`field_name` varchar(32) NOT NULL,
 	`field_description` varchar(128),
 	`validation_expression` varchar(64),
@@ -70,9 +71,10 @@ VALUES
 	('adwords', 'Google AdWords');";
 
 $sql[] = "INSERT INTO `"._DB_PREFIX_."conversiontracking_field`
-	(`id_conversiontracking_service`, `field_name`, `field_description`, `validation_expression`, `validation_message`)
+	(`id_conversiontracking_service`, `field_id`, `field_name`, `field_description`, `validation_expression`, `validation_message`)
 SELECT
 	`"._DB_PREFIX_."conversiontracking_service`.`id_conversiontracking_service`,
+	`fields`.`field_id`,
 	`fields`.`field_name`,
 	`fields`.`field_description`,
 	`fields`.`validation_expression`,
@@ -80,12 +82,14 @@ SELECT
 FROM `"._DB_PREFIX_."conversiontracking_service`
 INNER JOIN (
 	SELECT
+		'id' as `field_id`,
 		'ID' as `field_name`,
 		'google_conversion_id' as `field_description`,
 		'^[0-9]+$' as `validation_expression`,
 		'ID can only contain numbers' as `validation_message`
 	UNION ALL
 	SELECT
+		'label' as `field_id`,
 		'Label' as `field_name`,
 		'google_conversion_label' as `field_description`,
 		'^[A-Za-z0-9]+$' as `validation_expression`,
@@ -103,9 +107,10 @@ VALUES
 	('fbPixel', 'Facebook Conversion Tracking Pixel');";
 
 $sql[] = "INSERT INTO `"._DB_PREFIX_."conversiontracking_field`
-	(`id_conversiontracking_service`, `field_name`, `field_description`, `validation_expression`, `validation_message`)
+	(`id_conversiontracking_service`, `field_id`, `field_name`, `field_description`, `validation_expression`, `validation_message`)
 SELECT
 	`"._DB_PREFIX_."conversiontracking_service`.`id_conversiontracking_service`,
+	'id' as `field_id`,
 	'ID' as `field_name`,
 	'Checkout Pixel ID' as `field_description`,
 	'^[0-9]+$' as `validation_expression`,

--- a/sql/uninstall.php
+++ b/sql/uninstall.php
@@ -32,6 +32,11 @@
 
 $sql = array();
 
+$sql[] = 'DROP TABLE ps_conversiontracking_value;';
+$sql[] = 'DROP TABLE ps_conversiontracking;';
+$sql[] = 'DROP TABLE ps_conversiontracking_field;';
+$sql[] = 'DROP TABLE ps_conversiontracking_service;';
+
 foreach ($sql as $query)
 	if (Db::getInstance()->execute($query) == false)
 		return false;


### PR DESCRIPTION
Save conversion tracking script info in database. Allows scripts to be defined at "All", group, and shop levels
Fixes #1 
